### PR TITLE
feat: lifecycle hooks api

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -362,3 +362,83 @@ export class HelloWorldController {
 ```
 
 In this example, real `HelloWorldService` instance is `helloWorldService`, and custom object is `helloWorldService2`.
+
+## Lifecycle hooks
+
+You can hook and execute code before or after certain points in application bootstrap process. In order to do that you need to implement methods inside of you app root class (in our examples that is `Application` class inside of `src/main.ts`). Methods need to be decorated with proper decorator. Possible decorators (and obviously hooks) are (listed in order how they are actually executed):
+
+`BeforeGlobalMiddlewaresBound`
+
+`AfterGlobalMiddlewaresBound`
+
+`BeforeRoutesBound`
+
+`AfterRoutesBound`
+
+`BeforeListenStarted`
+
+`AfterListenStarted`
+
+Some of hooks overlap and they are equivalent but you shouldn't assume that. You should use exact hook you need because order of execution can change at any version and it won't be considered breaking change (if no other side effects).
+
+```typescript
+import { App, BeforeRoutesBound } from '@msabo1/expressts';
+import { HelloWorldController } from './hello-world.controller';
+import { HelloWorldService } from './hello-world.service';
+
+@App({
+  port: 3000,
+  controllers: [HelloWorldController],
+})
+export class Application {
+  constructor(private readonly helloWorldService: HelloWorldService) {}
+
+  @BeforeRoutesBound()
+  private beforeRoutes() {
+    console.log('I am executed just before routes are bound');
+    console.log(this.helloWorldService.findMessage());
+  }
+}
+```
+
+As you can see in this example, you can inject services and custom providers inside of your application root. You can inject controllers as well.
+
+## Express app instance
+
+You can access express app instance used to build server by injecting it in constructors with `ExpressAppInstance` decorator.
+
+```typescript
+import {
+  App,
+  BeforeRoutesBound,
+  AfterGlobalMiddlewaresBound,
+  ExpressAppInstance,
+} from '@msabo1/expressts';
+import { HelloWorldController } from './hello-world.controller';
+import { HelloWorldService } from './hello-world.service';
+import express from 'express';
+
+@App({
+  port: 3000,
+  controllers: [HelloWorldController],
+})
+export class Application {
+  constructor(
+    private readonly helloWorldService: HelloWorldService,
+    @ExpressAppInstance() private readonly expressApp: any,
+  ) {}
+
+  @BeforeRoutesBound()
+  private beforeRoutes() {
+    console.log('I am executed just before routes are bound');
+    console.log(this.helloWorldService.findMessage());
+  }
+
+  @AfterGlobalMiddlewaresBound()
+  private afterMiddlewares() {
+    this.expressApp.use(express.urlencoded());
+  }
+}
+```
+
+You can inject express app instance to controllers and services as well.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,9 @@
 
 ExpressTS (Express TypeScript) is decorator driven TypeScript framework on top of Express.js that allows you to use Express truly TypeScript way.
 
+[Github](https://github.com/msabo1/expressts)
+[Npm](https://www.npmjs.com/package/@msabo1/expressts)
+
 # Why
 
 Let's say you have decided you want use Express with Typescript. Great, there are type definitions for Express, just install them and you are using Express with TypeScript. But soon you realize that there is basically zero benefits of using TypeScript with Express that way (it even gets much more complicated). So you come up with idea to encapsulate some stuff in classes, it gets a bit prettier and you have some structure in your project. But again you realize you have actually done nothing. What to do next?

--- a/readme.md
+++ b/readme.md
@@ -362,3 +362,83 @@ export class HelloWorldController {
 ```
 
 In this example, real `HelloWorldService` instance is `helloWorldService`, and custom object is `helloWorldService2`.
+
+## Lifecycle hooks
+
+You can hook and execute code before or after certain points in application bootstrap process. In order to do that you need to implement methods inside of you app root class (in our examples that is `Application` class inside of `src/main.ts`). Methods need to be decorated with proper decorator. Possible decorators (and obviously hooks) are (listed in order how they are actually executed):
+
+`BeforeGlobalMiddlewaresBound`
+
+`AfterGlobalMiddlewaresBound`
+
+`BeforeRoutesBound`
+
+`AfterRoutesBound`
+
+`BeforeListenStarted`
+
+`AfterListenStarted`
+
+Some of hooks overlap and they are equivalent but you shouldn't assume that. You should use exact hook you need because order of execution can change at any version and it won't be considered breaking change (if no other side effects).
+
+```typescript
+import { App, BeforeRoutesBound } from '@msabo1/expressts';
+import { HelloWorldController } from './hello-world.controller';
+import { HelloWorldService } from './hello-world.service';
+
+@App({
+  port: 3000,
+  controllers: [HelloWorldController],
+})
+export class Application {
+  constructor(private readonly helloWorldService: HelloWorldService) {}
+
+  @BeforeRoutesBound()
+  private beforeRoutes() {
+    console.log('I am executed just before routes are bound');
+    console.log(this.helloWorldService.findMessage());
+  }
+}
+```
+
+As you can see in this example, you can inject services and custom providers inside of your application root. You can inject controllers as well.
+
+## Express app instance
+
+You can access express app instance used to build server by injecting it in constructors with `ExpressAppInstance` decorator.
+
+```typescript
+import {
+  App,
+  BeforeRoutesBound,
+  AfterGlobalMiddlewaresBound,
+  ExpressAppInstance,
+} from '@msabo1/expressts';
+import { HelloWorldController } from './hello-world.controller';
+import { HelloWorldService } from './hello-world.service';
+import express from 'express';
+
+@App({
+  port: 3000,
+  controllers: [HelloWorldController],
+})
+export class Application {
+  constructor(
+    private readonly helloWorldService: HelloWorldService,
+    @ExpressAppInstance() private readonly expressApp: any,
+  ) {}
+
+  @BeforeRoutesBound()
+  private beforeRoutes() {
+    console.log('I am executed just before routes are bound');
+    console.log(this.helloWorldService.findMessage());
+  }
+
+  @AfterGlobalMiddlewaresBound()
+  private afterMiddlewares() {
+    this.expressApp.use(express.urlencoded());
+  }
+}
+```
+
+You can inject express app instance to controllers and services as well.

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,9 @@
 
 ExpressTS (Express TypeScript) is decorator driven TypeScript framework on top of Express.js that allows you to use Express truly TypeScript way.
 
+[Github](https://github.com/msabo1/expressts)
+[Npm](https://www.npmjs.com/package/@msabo1/expressts)
+
 # Why
 
 Let's say you have decided you want use Express with Typescript. Great, there are type definitions for Express, just install them and you are using Express with TypeScript. But soon you realize that there is basically zero benefits of using TypeScript with Express that way (it even gets much more complicated). So you come up with idea to encapsulate some stuff in classes, it gets a bit prettier and you have some structure in your project. But again you realize you have actually done nothing. What to do next?

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -1,3 +1,3 @@
-export enum AppMetadataKey {
-  EXPRESS_APP_INSTANCE = 'instance:express',
+export enum AppProviderToken {
+  EXPRESS_APP_INSTANCE = 'express-app',
 }

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -1,0 +1,3 @@
+export enum AppMetadataKey {
+  EXPRESS_APP_INSTANCE = 'instance:express',
+}

--- a/src/app/bootstrap.service.ts
+++ b/src/app/bootstrap.service.ts
@@ -10,12 +10,16 @@ import { ResponseHeadersMetadataKey } from '../controllers/response-headers/resp
 import { DependencyContainer } from '../dependency-injection/dependency.container';
 import { Logger } from '../logger/logger';
 import { MiddlewareMetadataKey } from '../middleware/middleware.constants';
+import { AppMetadataKey } from './app.constants';
+import { LifecycleHookMetadataKey } from './lifecycle-hooks/lifecycle-hooks.constants';
+import { AppMetadata } from './types/app-metadata.type';
 import { AppProperties, CustomProvider } from './types/app-properties.type';
 import { ArgumentIndices } from './types/argument-indices.type';
 import { ControllerMetadata } from './types/controller-metadata.type';
 import { MethodMetadata } from './types/method-metadata.type';
 
 export class BootstrapService {
+  private appInstance: any;
   private readonly expressApp: express.Express;
   private readonly logger: Logger;
   constructor(
@@ -27,17 +31,96 @@ export class BootstrapService {
   }
 
   bootstrap() {
+    if (this.appProperties.customProviders) {
+      this.registerCustomProviders(this.appProperties.customProviders);
+    }
+    const appMetadata: AppMetadata = this.getAppMetadata();
+    this.createAppInstance(appMetadata.expressInstancePropertyKey);
+    // execute before hook
+    if (appMetadata.beforeGlobalMiddlewaresBoundMethodKey) {
+      this.appInstance[appMetadata.beforeGlobalMiddlewaresBoundMethodKey]();
+    }
+    // start middleware bind
     this.expressApp.use(express.json());
     this.appProperties.useGlobalMiddlewares?.forEach((middleware: RequestHandler) => {
       this.expressApp.use(middleware);
     });
-    if (this.appProperties.customProviders) {
-      this.registerCustomProviders(this.appProperties.customProviders);
+    // end middleware bind
+    // execute after hook
+    if (appMetadata.afterGlobalMiddlewaresBoundMethodKey) {
+      this.appInstance[appMetadata.afterGlobalMiddlewaresBoundMethodKey]();
     }
+    // execute before hook
+    if (appMetadata.beforeRoutesBoundMethodKey) {
+      this.appInstance[appMetadata.beforeRoutesBoundMethodKey]();
+    }
+    // start route bind
     if (this.appProperties.controllers) {
       this.registerControllers(this.appProperties.controllers);
     }
+    // end route bind
+    // execute after hook
+    if (appMetadata.afterRoutesBoundMethodKey) {
+      this.appInstance[appMetadata.afterRoutesBoundMethodKey]();
+    }
+    // execute before hook
+    if (appMetadata.beforeListenStartedMethodKey) {
+      this.appInstance[appMetadata.beforeListenStartedMethodKey]();
+    }
+    // start listen
     this.expressApp.listen(this.appProperties.port);
+    // end of start of listen
+    // execute after hook
+    if (appMetadata.afterListenStartedMethodKey) {
+      this.appInstance[appMetadata.afterListenStartedMethodKey]();
+    }
+  }
+
+  private createAppInstance(expressInstancePropertyKey?: string) {
+    this.appInstance = DependencyContainer.get(this.appClass);
+    if (expressInstancePropertyKey) {
+      this.appInstance[expressInstancePropertyKey] = this.expressApp;
+    }
+  }
+
+  private getAppMetadata(): AppMetadata {
+    const expressInstancePropertyKey: string = Reflect.getMetadata(
+      AppMetadataKey.EXPRESS_APP_INSTANCE,
+      this.appClass.prototype,
+    );
+    const beforeGlobalMiddlewaresBoundMethodKey: string = Reflect.getMetadata(
+      LifecycleHookMetadataKey.BEFORE_MIDDLEWARES_BOUND,
+      this.appClass.prototype,
+    );
+    const afterGlobalMiddlewaresBoundMethodKey: string = Reflect.getMetadata(
+      LifecycleHookMetadataKey.AFTER_MIDDLEWARES_BOUND,
+      this.appClass.prototype,
+    );
+    const beforeRoutesBoundMethodKey: string = Reflect.getMetadata(
+      LifecycleHookMetadataKey.BEFORE_ROUTES_BOUND,
+      this.appClass.prototype,
+    );
+    const afterRoutesBoundMethodKey: string = Reflect.getMetadata(
+      LifecycleHookMetadataKey.AFTER_ROUTES_BOUND,
+      this.appClass.prototype,
+    );
+    const beforeListenStartedMethodKey: string = Reflect.getMetadata(
+      LifecycleHookMetadataKey.BEFORE_LISTEN_STARTED,
+      this.appClass.prototype,
+    );
+    const afterListenStartedMethodKey: string = Reflect.getMetadata(
+      LifecycleHookMetadataKey.AFTER_LISTEN_STARTED,
+      this.appClass.prototype,
+    );
+    return {
+      expressInstancePropertyKey,
+      beforeGlobalMiddlewaresBoundMethodKey,
+      afterGlobalMiddlewaresBoundMethodKey,
+      beforeRoutesBoundMethodKey,
+      afterRoutesBoundMethodKey,
+      beforeListenStartedMethodKey,
+      afterListenStartedMethodKey,
+    };
   }
 
   private registerControllers(controllers: Constructible[]) {

--- a/src/app/decorators/express-app-instance.decorator.ts
+++ b/src/app/decorators/express-app-instance.decorator.ts
@@ -1,0 +1,7 @@
+import { AppMetadataKey } from '../app.constants';
+
+export function ExpressAppInstance(): PropertyDecorator {
+  return function (target: any, key: string | symbol) {
+    Reflect.defineMetadata(AppMetadataKey.EXPRESS_APP_INSTANCE, key, target);
+  };
+}

--- a/src/app/decorators/express-app-instance.decorator.ts
+++ b/src/app/decorators/express-app-instance.decorator.ts
@@ -1,7 +1,6 @@
-import { AppMetadataKey } from '../app.constants';
+import { Inject } from '../../dependency-injection';
+import { AppProviderToken } from '../app.constants';
 
-export function ExpressAppInstance(): PropertyDecorator {
-  return function (target: any, key: string | symbol) {
-    Reflect.defineMetadata(AppMetadataKey.EXPRESS_APP_INSTANCE, key, target);
-  };
+export function ExpressAppInstance(): ParameterDecorator {
+  return Inject(AppProviderToken.EXPRESS_APP_INSTANCE);
 }

--- a/src/app/decorators/index.ts
+++ b/src/app/decorators/index.ts
@@ -1,1 +1,2 @@
 export * from './app.decorator';
+export * from './express-app-instance.decorator';

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,1 +1,2 @@
 export * from './decorators';
+export * from './lifecycle-hooks';

--- a/src/app/lifecycle-hooks/index.ts
+++ b/src/app/lifecycle-hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './lifecycle-hook.decorators';

--- a/src/app/lifecycle-hooks/lifecycle-hook-decorator.factory.ts
+++ b/src/app/lifecycle-hooks/lifecycle-hook-decorator.factory.ts
@@ -1,0 +1,7 @@
+export function lifecycleHookDecoratorFactory(metadataKey: string): Function {
+  return function (): MethodDecorator {
+    return function (target: any, key: string | symbol) {
+      Reflect.defineMetadata(metadataKey, key, target);
+    };
+  };
+}

--- a/src/app/lifecycle-hooks/lifecycle-hook.decorators.ts
+++ b/src/app/lifecycle-hooks/lifecycle-hook.decorators.ts
@@ -1,0 +1,21 @@
+import { lifecycleHookDecoratorFactory } from './lifecycle-hook-decorator.factory';
+import { LifecycleHookMetadataKey } from './lifecycle-hooks.constants';
+
+export const BeforeGlobalMiddlewaresBound = lifecycleHookDecoratorFactory(
+  LifecycleHookMetadataKey.BEFORE_MIDDLEWARES_BOUND,
+);
+export const AfterGlobalMiddlewaresBound = lifecycleHookDecoratorFactory(
+  LifecycleHookMetadataKey.AFTER_MIDDLEWARES_BOUND,
+);
+export const BeforeRoutesBound = lifecycleHookDecoratorFactory(
+  LifecycleHookMetadataKey.BEFORE_ROUTES_BOUND,
+);
+export const AfterRoutesBound = lifecycleHookDecoratorFactory(
+  LifecycleHookMetadataKey.AFTER_ROUTES_BOUND,
+);
+export const BeforeListenStarted = lifecycleHookDecoratorFactory(
+  LifecycleHookMetadataKey.BEFORE_LISTEN_STARTED,
+);
+export const AfterListenStarted = lifecycleHookDecoratorFactory(
+  LifecycleHookMetadataKey.AFTER_LISTEN_STARTED,
+);

--- a/src/app/lifecycle-hooks/lifecycle-hooks.constants.ts
+++ b/src/app/lifecycle-hooks/lifecycle-hooks.constants.ts
@@ -1,0 +1,8 @@
+export enum LifecycleHookMetadataKey {
+  BEFORE_MIDDLEWARES_BOUND = 'lifecyclehook:before-middlewares',
+  AFTER_MIDDLEWARES_BOUND = 'lifecyclehook:after-middlewares',
+  BEFORE_ROUTES_BOUND = 'lifecyclehook:before-routes',
+  AFTER_ROUTES_BOUND = 'lifecyclehook:after-routes',
+  BEFORE_LISTEN_STARTED = 'lifecyclehook:before-listen',
+  AFTER_LISTEN_STARTED = 'lifecyclehook:after-listen',
+}

--- a/src/app/types/app-metadata.type.ts
+++ b/src/app/types/app-metadata.type.ts
@@ -1,5 +1,4 @@
 export interface AppMetadata {
-  expressInstancePropertyKey?: string;
   beforeGlobalMiddlewaresBoundMethodKey?: string;
   afterGlobalMiddlewaresBoundMethodKey?: string;
   beforeRoutesBoundMethodKey?: string;

--- a/src/app/types/app-metadata.type.ts
+++ b/src/app/types/app-metadata.type.ts
@@ -1,0 +1,9 @@
+export interface AppMetadata {
+  expressInstancePropertyKey?: string;
+  beforeGlobalMiddlewaresBoundMethodKey?: string;
+  afterGlobalMiddlewaresBoundMethodKey?: string;
+  beforeRoutesBoundMethodKey?: string;
+  afterRoutesBoundMethodKey?: string;
+  beforeListenStartedMethodKey?: string;
+  afterListenStartedMethodKey?: string;
+}


### PR DESCRIPTION
This pull request introduces lifecycle hooks.
You can hook before or after certain points in app bootstrap process and use express app instance directly inside of those hooks.

Closes #9 as injecting express instance is part of lifecycle hooks.

Docs created.